### PR TITLE
Update troubleshooting for ScopeRowCount error

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,9 @@ See [README_SECURE_IMPLEMENTATION.md](README_SECURE_IMPLEMENTATION.md) for detai
    - Check for blocking queries
    - Optimize source database indexes
 
+5. **ScopeRowCount Update Error**
+   - Versions prior to 1.5.1 could fail with a parameter count mismatch while updating `ScopeRowCount`, resulting in a `COUNT field incorrect or syntax error` during table conversions. Update to the latest code to resolve this issue.
+
 ### Debug Mode
 Enable verbose logging:
 ```bash


### PR DESCRIPTION
## Summary
- document that version 1.5.1 fixes a ScopeRowCount parameter count issue
- advise updating if `COUNT field incorrect or syntax error` occurs during table conversions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c734b29d483238dbaee2e8a6cf216