### PR TITLE
Unify importer implementations

### DIFF
--- a/etl/secure_base_importer.py
+++ b/etl/secure_base_importer.py
@@ -6,17 +6,14 @@ import logging
 from typing import Any
 
 from etl.base_importer import BaseDBImporter
-from utils.etl_helpers import load_sql, run_sql_script
-from utils.sql_security import validate_sql_statement
+
 
 logger = logging.getLogger(__name__)
 
 
 class SecureBaseDBImporter(BaseDBImporter):
-    """Base importer that validates SQL before execution."""
+    """Base importer that always enables extra validation."""
 
-    def run_sql_file(self, conn: Any, name: str, filename: str) -> None:
-        """Load a SQL file, validate it and execute using :func:`run_sql_script`."""
-        sql = load_sql(filename, self.db_name)
-        sql = validate_sql_statement(sql, allow_ddl=True)
-        run_sql_script(conn, name, sql, timeout=self.config["sql_timeout"])
+    def __init__(self) -> None:
+        super().__init__()
+        self.extra_validation = True


### PR DESCRIPTION
## Summary
- add `run_sql_file` helper to `BaseDBImporter`
- allow enabling SQL validation via `--extra-validation` CLI flag or `EJ_EXTRA_VALIDATION`
- update importer scripts to use `run_sql_file`
- make `SecureBaseDBImporter` enable validation by default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c7c0e51b08323802204bb88db3ca6