### PR TITLE
Add connection factory module for database utilities

### DIFF
--- a/01_JusticeDB_Import.py
+++ b/01_JusticeDB_Import.py
@@ -18,7 +18,7 @@ from dotenv import load_dotenv
 import pandas as pd
 import urllib
 import sqlalchemy
-from db.mssql import get_target_connection
+from db.connections import get_target_connection
 from tqdm import tqdm
 from etl import core
 from etl import BaseDBImporter

--- a/02_OperationsDB_Import.py
+++ b/02_OperationsDB_Import.py
@@ -18,7 +18,7 @@ from dotenv import load_dotenv
 import pandas as pd
 import urllib
 import sqlalchemy
-from db.mssql import get_target_connection
+from db.connections import get_target_connection
 from etl import core
 from etl import BaseDBImporter
 from tqdm import tqdm

--- a/03_FinancialDB_Import.py
+++ b/03_FinancialDB_Import.py
@@ -17,7 +17,7 @@ from dotenv import load_dotenv
 import pandas as pd
 import urllib
 import sqlalchemy
-from db.mssql import get_target_connection
+from db.connections import get_target_connection
 from etl import core
 from etl import BaseDBImporter
 from tqdm import tqdm

--- a/04_LOBColumns.py
+++ b/04_LOBColumns.py
@@ -25,7 +25,7 @@ import tkinter as tk
 from tkinter import messagebox
 
 import pyodbc
-from db.mssql import get_target_connection
+from db.connections import get_target_connection
 from utils.logging_helper import setup_logging, operation_counts
 from config import settings, parse_database_name, ETLConstants
 

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,13 +1,20 @@
 """Database connection utilities."""
 
-from .mssql import get_source_connection, get_target_connection
-from .mysql import get_mysql_connection
+from .connections import (
+    get_source_connection,
+    get_target_connection,
+    get_mysql_connection,
+    get_engine,
+    get_connection,
+)
 from .health import check_connection, check_target_connection
 
 __all__ = [
     "get_source_connection",
     "get_target_connection",
     "get_mysql_connection",
+    "get_engine",
+    "get_connection",
     "check_connection",
     "check_target_connection",
 ]

--- a/db/connections.py
+++ b/db/connections.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import os
+import urllib.parse
+from typing import Any
+
+from dotenv import load_dotenv
+import sqlalchemy
+from sqlalchemy.engine import URL
+from config import settings
+
+Engine = Any  # runtime fallback for type hints
+Connection = Any
+
+# Ensure environment variables from .env are loaded like previous modules
+load_dotenv()
+
+_engines: dict[str, Engine] = {}
+
+
+def build_mssql_url(conn_str: str) -> URL:
+    """Return an SQLAlchemy URL for an ODBC connection string."""
+    encoded = urllib.parse.quote_plus(conn_str)
+    return URL.create("mssql+pyodbc", query={"odbc_connect": encoded})
+
+
+def build_mysql_url(
+    host: str,
+    user: str,
+    password: str,
+    database: str,
+    port: int = 3306,
+) -> URL:
+    """Return a MySQL connection URL using mysqlconnector."""
+    return URL.create(
+        "mysql+mysqlconnector",
+        username=user,
+        password=password,
+        host=host,
+        port=port,
+        database=database,
+    )
+
+
+def get_engine(url: URL | str) -> Engine:
+    """Return (and cache) a SQLAlchemy engine for ``url``."""
+    key = str(url)
+    engine = _engines.get(key)
+    if engine is None:
+        engine = sqlalchemy.create_engine(
+            url,
+            pool_size=settings.db_pool_size,
+            max_overflow=settings.db_max_overflow,
+            pool_timeout=settings.db_pool_timeout,
+            pool_pre_ping=True,
+        )
+        _engines[key] = engine
+    return engine
+
+
+def get_connection(url: URL | str) -> Connection:
+    """Return a pooled connection for ``url``."""
+    return get_engine(url).connect()
+
+
+def get_mssql_connection(conn_str: str) -> Connection:
+    """Return a connection using an ODBC connection string."""
+    return get_connection(build_mssql_url(conn_str))
+
+
+def get_source_connection() -> Connection:
+    """Connect to the configured MSSQL source database."""
+    conn = settings.mssql_source_conn_str
+    return get_mssql_connection(conn.get_secret_value() if conn else "")
+
+
+def get_target_connection() -> Connection:
+    """Connect to the configured MSSQL target database."""
+    conn = settings.mssql_target_conn_str
+    return get_mssql_connection(conn.get_secret_value())
+
+
+def get_mysql_connection(
+    host: str | None = None,
+    user: str | None = None,
+    password: str | None = None,
+    database: str | None = None,
+    port: int | None = None,
+) -> Connection:
+    """Return a pooled MySQL connection using provided args or configuration."""
+    host = host or os.getenv("MYSQL_HOST") or settings.mysql_host
+    user = user or os.getenv("MYSQL_USER") or settings.mysql_user
+    env_pass = os.getenv("MYSQL_PASSWORD")
+    settings_pass = (
+        settings.mysql_password.get_secret_value() if settings.mysql_password else None
+    )
+    password = password or env_pass or settings_pass
+    database = database or os.getenv("MYSQL_DATABASE") or settings.mysql_database
+    port_value = port or os.getenv("MYSQL_PORT") or settings.mysql_port or 3306
+    port = int(port_value)
+
+    if not all([host, user, password, database]):
+        raise ValueError("Missing required MySQL connection parameters.")
+
+    return get_connection(build_mysql_url(host, user, password, database, port))
+
+
+__all__ = [
+    "build_mssql_url",
+    "build_mysql_url",
+    "get_engine",
+    "get_connection",
+    "get_mssql_connection",
+    "get_source_connection",
+    "get_target_connection",
+    "get_mysql_connection",
+]

--- a/db/mssql.py
+++ b/db/mssql.py
@@ -1,57 +1,26 @@
-"""Convenience wrappers for establishing MSSQL connections."""
-
 from __future__ import annotations
 
-import urllib.parse
-import sqlalchemy
-from sqlalchemy.pool import NullPool
-from typing import TYPE_CHECKING, Any
+"""Convenience wrappers for establishing MSSQL connections."""
 
-if TYPE_CHECKING:
-    from sqlalchemy.engine import Engine, Connection
+from typing import Any
+
+from .connections import (
+    build_mssql_url,
+    get_engine,
+    get_connection,
+    get_mssql_connection,
+    get_source_connection,
+    get_target_connection,
+)
 
 Engine = Any  # runtime fallback for type hints
 Connection = Any
 
-from config import settings
-
-_engines: dict[str, Engine] = {}
-
-def _get_engine(conn_str: str) -> Engine:
-    """Return (and cache) a SQLAlchemy engine for the given connection string."""
-    conn_str += ";connection timeout=30;command timeout=30"
-    engine = _engines.get(conn_str)
-    if engine is None:
-        params = urllib.parse.quote_plus(conn_str)
-        url = f"mssql+pyodbc:///?odbc_connect={params}"
-        engine = sqlalchemy.create_engine(
-            url,
-            echo=False,  # Set to True for debugging
-            pool_pre_ping=True,
-            pool_size=5,
-            max_overflow=10,
-            pool_timeout=settings.db_pool_timeout,
-        )
-        _engines[conn_str] = engine
-    return engine
-
-
-def get_mssql_connection(conn_str: str) -> Connection:
-    """Return a pooled connection using the given connection string."""
-    return _get_engine(conn_str).connect()
-
-def get_source_connection() -> Connection:
-    """Connect to the source MSSQL database configured in settings."""
-    conn = settings.mssql_source_conn_str
-    return get_mssql_connection(conn.get_secret_value() if conn else "")
-
-def get_target_connection() -> Connection:
-    """Connect to the target MSSQL database configured in settings."""
-    conn = settings.mssql_target_conn_str
-    return get_mssql_connection(conn.get_secret_value())
-
-# Use explicit metadata loading instead of reflection
-metadata = sqlalchemy.MetaData()
-# Only load tables you need explicitly
-# table = Table('your_table', metadata, autoload_with=engine)
-
+__all__ = [
+    "build_mssql_url",
+    "get_engine",
+    "get_connection",
+    "get_mssql_connection",
+    "get_source_connection",
+    "get_target_connection",
+]

--- a/db/mysql.py
+++ b/db/mysql.py
@@ -1,63 +1,22 @@
-import os
-from dotenv import load_dotenv
-import sqlalchemy
-from typing import TYPE_CHECKING, Any, Optional, Union
+from __future__ import annotations
 
-if TYPE_CHECKING:
-    from sqlalchemy.engine import Engine, Connection
+"""Convenience wrappers for establishing MySQL connections."""
+
+from typing import Any
+
+from .connections import (
+    build_mysql_url,
+    get_engine,
+    get_connection,
+    get_mysql_connection,
+)
 
 Engine = Any
 Connection = Any
-from config import settings
 
-from sqlalchemy.engine import Engine, Connection
-_engine: Union[Engine, None] = None
-
-# Load environment variables from .env file so manual calls behave the same
-load_dotenv()
-
-def _get_engine(
-    host: str,
-    user: str,
-    password: str,
-    database: str,
-    port: int,
-) -> Engine:
-    """Return (and cache) a SQLAlchemy engine for the given parameters."""
-    global _engine
-    if _engine is None:
-        url = (
-            f"mysql+mysqlconnector://{user}:{password}@{host}:{port}/{database}"
-        )
-        _engine = sqlalchemy.create_engine(
-            url,
-            pool_size=settings.db_pool_size,
-            max_overflow=settings.db_max_overflow,
-            pool_timeout=settings.db_pool_timeout,
-            pool_pre_ping=True,
-        )
-    return _engine
-
-
-def get_mysql_connection(
-    host: str = None,
-    user: str = None,
-    password: str = None,
-    database: str = None,
-    port: int = None,
-) -> Connection:
-    """Return a pooled MySQL connection using provided args or configuration."""
-    host = host or os.getenv('MYSQL_HOST') or settings.mysql_host
-    user = user or os.getenv('MYSQL_USER') or settings.mysql_user
-    env_pass = os.getenv('MYSQL_PASSWORD')
-    settings_pass = settings.mysql_password.get_secret_value() if settings.mysql_password else None
-    password = password or env_pass or settings_pass
-    database = database or os.getenv('MYSQL_DATABASE') or settings.mysql_database
-    port_value = port or os.getenv('MYSQL_PORT') or settings.mysql_port or 3306
-    port = int(port_value)
-
-    if not all([host, user, password, database]):
-        raise ValueError("Missing required MySQL connection parameters.")
-
-    engine = _get_engine(host, user, password, database, port)
-    return engine.connect()
+__all__ = [
+    "build_mysql_url",
+    "get_engine",
+    "get_connection",
+    "get_mysql_connection",
+]

--- a/etl/base_importer.py
+++ b/etl/base_importer.py
@@ -14,7 +14,7 @@ import sqlalchemy
 from typing import Any, Optional
 from sqlalchemy.types import Text
 
-from db.mssql import get_target_connection
+from db.connections import get_target_connection
 from utils.etl_helpers import (
     load_sql,
     run_sql_script,

--- a/tests/test_base_importer.py
+++ b/tests/test_base_importer.py
@@ -25,6 +25,7 @@ if "sqlalchemy" not in sys.modules:
     engine_mod = types.ModuleType("engine")
     engine_mod.Engine = object
     engine_mod.Connection = object
+    engine_mod.URL = types.SimpleNamespace(create=lambda *a, **k: None)
     sa_mod.engine = engine_mod
     sys.modules["sqlalchemy"] = sa_mod
     sys.modules["sqlalchemy.types"] = types_mod

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -11,6 +11,7 @@ if "sqlalchemy" not in sys.modules:
     engine_mod = types.ModuleType("engine")
     engine_mod.Engine = object
     engine_mod.Connection = object
+    engine_mod.URL = types.SimpleNamespace(create=lambda *a, **k: None)
     sa_mod.engine = engine_mod
     sys.modules["sqlalchemy"] = sa_mod
     sys.modules["sqlalchemy.pool"] = pool_mod

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -19,6 +19,7 @@ if "sqlalchemy" not in sys.modules:
     engine_mod = types.ModuleType("engine")
     engine_mod.Engine = object
     engine_mod.Connection = object
+    engine_mod.URL = types.SimpleNamespace(create=lambda *a, **k: None)
     sa_mod.engine = engine_mod
     sys.modules["sqlalchemy"] = sa_mod
     sys.modules["sqlalchemy.types"] = sa_mod.types
@@ -65,7 +66,7 @@ if "pydantic" not in sys.modules:
     sys.modules["pydantic_settings"] = ps_mod
 
 from etl.base_importer import BaseDBImporter
-import db.mssql as mssql
+import db.connections as connections
 
 
 class MiniImporter(BaseDBImporter):
@@ -177,7 +178,7 @@ def test_end_to_end_mini_importer(monkeypatch, tmp_path):
     conn = sqlite3.connect(":memory:")
 
     # Patch the connection retrieval used inside BaseDBImporter
-    monkeypatch.setattr(mssql, "get_target_connection", lambda: conn)
+    monkeypatch.setattr(connections, "get_target_connection", lambda: conn)
     monkeypatch.setattr("etl.base_importer.get_target_connection", lambda: conn)
 
     importer = MiniImporter()
@@ -206,7 +207,7 @@ def test_end_to_end_full_importer(monkeypatch, tmp_path):
 
     conn = sqlite3.connect(":memory:")
 
-    monkeypatch.setattr(mssql, "get_target_connection", lambda: conn)
+    monkeypatch.setattr(connections, "get_target_connection", lambda: conn)
     monkeypatch.setattr("etl.base_importer.get_target_connection", lambda: conn)
 
     importer = FullImporter()

--- a/tests/test_mssql.py
+++ b/tests/test_mssql.py
@@ -18,6 +18,7 @@ if "sqlalchemy" not in sys.modules:
     engine_mod = types.ModuleType("engine")
     engine_mod.Engine = object
     engine_mod.Connection = object
+    engine_mod.URL = types.SimpleNamespace(create=lambda *a, **k: None)
     sa_mod.engine = engine_mod
     sys.modules["sqlalchemy"] = sa_mod
     sys.modules["sqlalchemy.engine"] = engine_mod
@@ -46,7 +47,7 @@ if "pydantic" not in sys.modules:
     ps_mod = types.ModuleType("pydantic_settings")
     ps_mod.BaseSettings = _BaseSettings
     sys.modules["pydantic_settings"] = ps_mod
-import db.mssql as mssql
+import db.connections as connections
 from config import settings
 
 class DummyConn:
@@ -73,8 +74,8 @@ def test_get_target_connection(monkeypatch):
     monkeypatch.setattr(settings, 'db_pool_size', 5, raising=False)
     monkeypatch.setattr(settings, 'db_max_overflow', 10, raising=False)
     monkeypatch.setattr(settings, 'db_pool_timeout', 30, raising=False)
-    monkeypatch.setattr(mssql.sqlalchemy, 'create_engine', fake_create_engine, raising=False)
+    monkeypatch.setattr(connections.sqlalchemy, 'create_engine', fake_create_engine, raising=False)
 
-    conn = mssql.get_target_connection()
+    conn = connections.get_target_connection()
     assert isinstance(conn, DummyConn)
     assert created['kwargs']['pool_size'] == settings.db_pool_size


### PR DESCRIPTION
## Summary
- centralize engine/connection creation in `db/connections.py`
- simplify `db.mssql` and `db.mysql` to re-export helpers from the new module
- update project modules and ETL scripts to use the unified connection helpers
- adapt tests to reference the new module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c8211bba0832392dd682538caea60