### PR TITLE
Add docstrings across ETL modules

### DIFF
--- a/01_JusticeDB_Import.py
+++ b/01_JusticeDB_Import.py
@@ -1,9 +1,9 @@
 """ETL script to migrate Justice database tables to the target server.
 
-The script loads SQL files under ``sql_scripts/justice`` and executes them
-against the database specified via ``MSSQL_TARGET_CONN_STR``.  Command line
-arguments allow overriding the log file location, CSV directory and other
-options.
+SQL files under ``sql_scripts/justice`` are executed against the database
+specified via ``MSSQL_TARGET_CONN_STR``. Command line options allow overriding
+the log and CSV locations. See ``README.md`` under ``Quick Start`` and ``ETL
+Process Flow`` for usage details.
 """
 
 import logging
@@ -55,7 +55,11 @@ class JusticeDBImporter(BaseDBImporter):
     DEFAULT_CSV_FILE = "EJ_Justice_Selects_ALL.csv"
     
     def parse_args(self) -> argparse.Namespace:
-        """Parse command line arguments for the Justice DB import script."""
+        """Parse command line arguments for the Justice DB import script.
+
+        Command usage examples are provided in the ``Quick Start`` section of
+        ``README.md``.
+        """
         parser = argparse.ArgumentParser(description="Justice DB Import ETL Process")
         parser.add_argument(
             "--log-file",

--- a/01_JusticeDB_Import_Secure.py
+++ b/01_JusticeDB_Import_Secure.py
@@ -1,4 +1,9 @@
-"""Simplified secure Justice database import."""
+"""Simplified secure Justice database import.
+
+This version uses the hardened ``SecureBaseDBImporter`` and is intended for
+production use. See ``README_SECURE_IMPLEMENTATION.md`` for migration steps and
+additional security notes.
+"""
 
 import logging
 from typing import Any
@@ -17,6 +22,7 @@ class SecureJusticeDBImporter(SecureBaseDBImporter):
     DEFAULT_CSV_FILE = "EJ_Justice_Selects_ALL.csv"
 
     def execute_preprocessing(self, conn: Any) -> None:
+        """Run SQL scripts that define the Justice supervision scope."""
         logger.info("Defining supervision scope for Justice DB")
         steps = [
             ("GatherCaseIDs", "justice/gather_caseids.sql"),
@@ -32,19 +38,23 @@ class SecureJusticeDBImporter(SecureBaseDBImporter):
         logger.info("Justice preprocessing complete")
 
     def prepare_drop_and_select(self, conn: Any) -> None:
+        """Generate DROP and SELECT statements for the Justice tables."""
         logger.info("Gathering list of Justice tables")
         self.run_sql_file(conn, "gather_drops_and_selects", "justice/gather_drops_and_selects.sql")
 
     def update_joins_in_tables(self, conn: Any) -> None:
+        """Insert JOIN statements into the tracking table."""
         logger.info("Updating JOINS in TablesToConvert")
         self.run_sql_file(conn, "update_joins", "justice/update_joins.sql")
         logger.info("Updating JOINS for Justice tables is complete")
 
     def get_next_step_name(self) -> str:
+        """Return the next importer to run after this one."""
         return "Operations migration"
 
 
 def main() -> None:
+    """Entry point for running the secure Justice importer from the CLI."""
     setup_logging()
     importer = SecureJusticeDBImporter()
     importer.run()

--- a/02_OperationsDB_Import.py
+++ b/02_OperationsDB_Import.py
@@ -1,9 +1,9 @@
 """ETL script to migrate Operations database tables.
 
-The script reads SQL under ``sql_scripts/operations`` and applies it to the
-database defined by the ``MSSQL_TARGET_CONN_STR`` environment variable.  Command
-line arguments mirror those of ``01_JusticeDB_Import.py`` allowing CSV and log
-locations to be overridden.
+The importer executes SQL from ``sql_scripts/operations`` against the database
+configured via ``MSSQL_TARGET_CONN_STR``. Command line options mirror those of
+the Justice importer. Consult ``README.md`` for ``Quick Start`` instructions
+and the overall ``ETL Process Flow``.
 """
 
 import logging
@@ -53,7 +53,10 @@ class OperationsDBImporter(BaseDBImporter):
     DEFAULT_CSV_FILE = "EJ_Operations_Selects_ALL.csv"
     
     def parse_args(self) -> argparse.Namespace:
-        """Parse command line arguments for the Operations DB import script."""
+        """Parse command line arguments for the Operations DB import script.
+
+        Example usage can be found in ``README.md`` under ``Quick Start``.
+        """
         parser = argparse.ArgumentParser(description="Operations DB Import ETL Process")
         parser.add_argument(
             "--log-file",

--- a/02_OperationsDB_Import_Secure.py
+++ b/02_OperationsDB_Import_Secure.py
@@ -1,4 +1,9 @@
-"""Simplified secure Operations database import."""
+"""Simplified secure Operations database import.
+
+Uses ``SecureBaseDBImporter`` for hardened execution. Refer to
+``README_SECURE_IMPLEMENTATION.md`` for usage guidance and security
+considerations.
+"""
 
 import logging
 from typing import Any
@@ -16,6 +21,7 @@ class SecureOperationsDBImporter(SecureBaseDBImporter):
     DEFAULT_CSV_FILE = "EJ_Operations_Selects_ALL.csv"
 
     def execute_preprocessing(self, conn: Any) -> None:
+        """Execute scripts to collect Operations DB scope information."""
         logger.info("Defining document conversion scope for Operations DB")
         steps = [("GatherDocumentIDs", "operations/gather_documentids.sql")]
         with transaction_scope(conn):
@@ -24,6 +30,7 @@ class SecureOperationsDBImporter(SecureBaseDBImporter):
         logger.info("Operations preprocessing complete")
 
     def prepare_drop_and_select(self, conn: Any) -> None:
+        """Generate DROP and SELECT statements for Operations tables."""
         logger.info("Gathering list of Operations tables")
         self.run_sql_file(
             conn,
@@ -32,15 +39,18 @@ class SecureOperationsDBImporter(SecureBaseDBImporter):
         )
 
     def update_joins_in_tables(self, conn: Any) -> None:
+        """Insert JOIN statements into the tracking table."""
         logger.info("Updating JOINS in TablesToConvert")
         self.run_sql_file(conn, "update_joins", "operations/update_joins_operations.sql")
         logger.info("Updating JOINS for Operations tables is complete")
 
     def get_next_step_name(self) -> str:
+        """Return the next importer to run after this one."""
         return "Financial migration"
 
 
 def main() -> None:
+    """Entry point for running the secure Operations importer from the CLI."""
     setup_logging()
     importer = SecureOperationsDBImporter()
     importer.run()

--- a/03_FinancialDB_Import.py
+++ b/03_FinancialDB_Import.py
@@ -1,8 +1,9 @@
 """ETL script to migrate Financial database tables to the target server.
 
-SQL files under ``sql_scripts/financial`` are executed in sequence.  Environment
-variables and command line options control the log path, CSV file location and
-whether empty tables are processed.
+SQL under ``sql_scripts/financial`` is executed sequentially. Environment
+variables and command line options control logging, CSV paths and the handling
+of empty tables. See ``README.md`` for setup details and the ``ETL Process
+Flow``.
 """
 
 import logging
@@ -52,7 +53,10 @@ class FinancialDBImporter(BaseDBImporter):
     DEFAULT_CSV_FILE = "EJ_Financial_Selects_ALL.csv"
     
     def parse_args(self) -> argparse.Namespace:
-        """Parse command line arguments for the Financial DB import script."""
+        """Parse command line arguments for the Financial DB import script.
+
+        Example usage can be found in ``README.md`` under ``Quick Start``.
+        """
         parser = argparse.ArgumentParser(description="Financial DB Import ETL Process")
         parser.add_argument(
             "--log-file",

--- a/03_FinancialDB_Import_Secure.py
+++ b/03_FinancialDB_Import_Secure.py
@@ -1,4 +1,8 @@
-"""Simplified secure Financial database import."""
+"""Simplified secure Financial database import.
+
+Leverages ``SecureBaseDBImporter`` for production environments. For details on
+the security model see ``README_SECURE_IMPLEMENTATION.md``.
+"""
 
 import logging
 from typing import Any
@@ -16,6 +20,7 @@ class SecureFinancialDBImporter(SecureBaseDBImporter):
     DEFAULT_CSV_FILE = "EJ_Financial_Selects_ALL.csv"
 
     def execute_preprocessing(self, conn: Any) -> None:
+        """Run SQL scripts that define the Financial supervision scope."""
         logger.info("Defining supervision scope for Financial DB")
         steps = [("GatherFeeInstanceIDs", "financial/gather_feeinstanceids.sql")]
         with transaction_scope(conn):
@@ -24,6 +29,7 @@ class SecureFinancialDBImporter(SecureBaseDBImporter):
         logger.info("Financial preprocessing complete")
 
     def prepare_drop_and_select(self, conn: Any) -> None:
+        """Generate DROP and SELECT statements for Financial tables."""
         logger.info("Gathering list of Financial tables")
         self.run_sql_file(
             conn,
@@ -32,15 +38,18 @@ class SecureFinancialDBImporter(SecureBaseDBImporter):
         )
 
     def update_joins_in_tables(self, conn: Any) -> None:
+        """Insert JOIN statements into the tracking table."""
         logger.info("Updating JOINS in TablesToConvert")
         self.run_sql_file(conn, "update_joins_financial", "financial/update_joins_financial.sql")
         logger.info("Updating JOINS for Financial tables is complete")
 
     def get_next_step_name(self) -> str:
+        """Return the next importer to run after this one."""
         return "LOB Columns"
 
 
 def main() -> None:
+    """Entry point for running the secure Financial importer from the CLI."""
     setup_logging()
     importer = SecureFinancialDBImporter()
     importer.run()

--- a/04_LOBColumns.py
+++ b/04_LOBColumns.py
@@ -1,9 +1,9 @@
 """Optimize LOB columns for migration by determining appropriate sizes.
 
 This script analyzes large object columns in the target database and writes
-ALTER statements to resize them as needed.  It relies on configuration from
-``MSSQL_TARGET_CONN_STR`` and accepts command line options for logging and
-batch size.
+``ALTER`` statements to resize them as needed. Configuration is read from
+``MSSQL_TARGET_CONN_STR`` and command line arguments. For context on how this
+fits into the overall migration see ``README.md`` under ``ETL Process Flow``.
 """
 
 from __future__ import annotations
@@ -47,7 +47,10 @@ conn_val = settings.mssql_target_conn_str.get_secret_value() if settings.mssql_t
 DB_NAME = settings.mssql_target_db_name or parse_database_name(conn_val)
 
 def parse_args() -> argparse.Namespace:
-    """Parse command line arguments for the LOB Column processing script."""
+    """Parse command line arguments for the LOB Column processing script.
+
+    Refer to ``README.md`` for an overview of expected options and defaults.
+    """
     parser = argparse.ArgumentParser(description="LOB Column Processing")
     parser.add_argument(
         "--log-file",

--- a/db/mssql.py
+++ b/db/mssql.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-"""Convenience wrappers for establishing MSSQL connections."""
+"""Convenience wrappers for establishing MSSQL connections.
+
+This module re-exports connection helpers used throughout the ETL scripts.
+Connection string details are documented in the ``Configuration`` section of
+``README.md``.
+"""
 
 from typing import Any
 

--- a/etl/core.py
+++ b/etl/core.py
@@ -1,4 +1,10 @@
-"""Core ETL utilities shared across all database import scripts."""
+"""Core ETL utilities shared across all database import scripts.
+
+These helpers provide environment validation, configuration loading and
+SQL execution utilities used by the importer modules.  For an overview of
+the entire ETL pipeline and configuration options see the ``Architecture``
+and ``Configuration`` sections of ``README.md``.
+"""
 
 from __future__ import annotations
 
@@ -26,7 +32,11 @@ class ConfigError(Exception):
 
 
 def validate_environment(required_vars: Dict[str, str], optional_vars: Dict[str, str]) -> None:
-    """Validate environment variables with custom requirements."""
+    """Validate environment variables against required and optional sets.
+
+    Refer to the ``Environment Variables`` table in ``README.md`` for a
+    description of available settings.
+    """
     # Check required vars
     missing = []
     for var, desc in required_vars.items():
@@ -51,7 +61,11 @@ def validate_environment(required_vars: Dict[str, str], optional_vars: Dict[str,
         raise EnvironmentError(f"EJ_CSV_DIR directory does not exist: {csv_dir}")
 
 def load_config(config_file: str | None = None, default_config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    """Load configuration from JSON file if provided, otherwise use defaults."""
+    """Load configuration from JSON file or fall back to defaults.
+
+    The expected structure of the configuration file is documented in the
+    ``Configuration`` section of ``README.md``.
+    """
     config: Dict[str, Any] = default_config or {}
     
     if config_file and os.path.exists(config_file):
@@ -76,10 +90,11 @@ def sanitize_sql(
 ) -> Any:
     """Execute a SQL statement using parameterized queries.
 
-    This function previously attempted to sanitize SQL strings with regular
-    expressions which provided limited protection against injection attacks.
-    The new implementation delegates execution to ``execute_sql_with_timeout``
-    which supports parameterized queries.
+    Earlier versions sanitized SQL via regular expressions which provided only
+    limited protection.  ``sanitize_sql`` now delegates to
+    ``execute_sql_with_timeout`` which enforces parameterization.  See the
+    ``Security Considerations`` section in ``README.md`` for additional
+    guidance.
     """
 
     if sql_text is None:
@@ -88,7 +103,11 @@ def sanitize_sql(
     return execute_sql_with_timeout(conn, sql_text, params=params, timeout=timeout)
 
 def safe_tqdm(iterable: Iterable[T], **kwargs: Any) -> Iterator[T]:
-    """Wrapper for tqdm that falls back to a simple iterator if tqdm fails."""
+    """Wrapper for ``tqdm`` that degrades gracefully if progress bars fail.
+
+    Progress display is optional and can be tuned as described in the
+    ``Performance Tuning`` section of ``README.md``.
+    """
     try:
         # First try with default settings
         for item in tqdm(iterable, **kwargs):
@@ -108,6 +127,8 @@ def validate_sql_identifier(identifier: str) -> str:
     """Validate a string for use as a SQL identifier.
 
     Only allows alphanumeric characters and underscores and must not start with a digit.
+    Validation mirrors the guidelines outlined under ``Security Considerations``
+    in ``README.md``.
 
     Args:
         identifier: The identifier to validate.


### PR DESCRIPTION
## Summary
- expand module-level docstrings for ETL utilities and importers
- reference README sections in docstrings for context
- document secure importer functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c8c13ace483239ea0cf1f17554863